### PR TITLE
return false when input is not a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,10 @@ function isFQDN(_str, {
 	allowUnderscores = false,
 	allowTrailingDot = false
 } = {}) {
+	if (typeof _str !== 'string') {
+		return false;
+	}
+
 	const str = removeOptionalTrailingDot(_str, allowTrailingDot);
 	const parts = str.split('.');
 

--- a/test.js
+++ b/test.js
@@ -33,7 +33,10 @@ test('without trailing dots', t => {
 			'*.some.com',
 			's!ome.com',
 			'domain.com/',
-			'/more.com'
+			'/more.com',
+			null,
+			undefined,
+			123
 		]
 	});
 });


### PR DESCRIPTION
Now, it won't throw a `Cannot read property 'split' of undefined` and similar errors any more.